### PR TITLE
Add support for Minecraft 1.21.9 and 1.21.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     modApi("me.shedaniel.cloth:cloth-config-fabric:${property("cloth_version")}") {
         exclude("net.fabricmc.fabric-api")
     }
-    modApi("com.terraformersmc:modmenu:${property("modmenu_version")}")
+    modCompileOnly("com.terraformersmc:modmenu:${property("modmenu_version")}")
     modRuntimeOnly("net.fabricmc.fabric-api:fabric-api:${property("fabric_version")}")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=[VERSIONED]
 minecraft_version_dependency=[VERSIONED]
-loader_version=0.16.9
+loader_version=0.17.3
 # Mod Properties
 mod_version=1.1.0
 maven_group=com.github.apehum
 archives_base_name=bundle-weight-counter
 cloth_version=16.0.143
-modmenu_version=12.0.0
+modmenu_version=13.0.0
 fabric_version=[VERSIONED]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 stonecutter {
     create(rootProject) {
-        versions("1.21.2", "1.21.5")
+        versions("1.21.2", "1.21.5", "1.21.9", "1.21.10")
     }
 }
 

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     id("dev.kikugie.stonecutter")
 }
-stonecutter active "1.21.2"
+
+stonecutter active "1.21.10"

--- a/versions/1.21.10/gradle.properties
+++ b/versions/1.21.10/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.21.10
+minecraft_version_dependency=>=1.21.10
+fabric_version=0.138.3+1.21.10

--- a/versions/1.21.9/gradle.properties
+++ b/versions/1.21.9/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.21.9
+minecraft_version_dependency=>=1.21.9
+fabric_version=0.134.0+1.21.9


### PR DESCRIPTION
This PR adds support for Minecraft versions 1.21.9 and 1.21.10.
     
     Changes made:
     - Created version folders for 1.21.9 and 1.21.10 with appropriate gradle.properties
     - Updated Fabric Loader to 0.17.3
     - Updated Fabric API versions (0.134.0+1.21.9 and 0.138.3+1.21.10)
     - Registered new versions in settings.gradle.kts
     - Changed ModMenu dependency to compileOnly to avoid runtime conflicts
     - Tested and confirmed working on both versions